### PR TITLE
fix: no commit message

### DIFF
--- a/lua/gitsigns/git.lua
+++ b/lua/gitsigns/git.lua
@@ -638,7 +638,7 @@ function Obj:run_blame(lines, lnum, ignore_whitespace)
   -- The output given by "git blame" that attributes a line to contents
   -- taken from the file specified by the "--contents" option shows it
   -- differently from a line attributed to the working tree file.
-  if ret.author_mail == '<external.file>' then
+  if ret.author_mail == '<external.file>' or ret.author_mail == 'External file (--contents)' then
     ret = vim.tbl_extend('force', ret, not_committed)
   end
 


### PR DESCRIPTION
Fix no commit message.

<img width="847" alt="image" src="https://github.com/Aryonal/gitsigns.nvim/assets/10463542/44676442-0595-42e3-938e-4ce586e2bdd5">

After fix

<img width="864" alt="image" src="https://github.com/Aryonal/gitsigns.nvim/assets/10463542/a68848d2-f842-4649-8fc9-28e849e23041">

